### PR TITLE
Add product API controller

### DIFF
--- a/Controllers/ProductsController.cs
+++ b/Controllers/ProductsController.cs
@@ -1,0 +1,97 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using RoleBasedProductAPI.Data;
+using RoleBasedProductAPI.Models;
+
+namespace RoleBasedProductAPI.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class ProductsController : ControllerBase
+    {
+        private readonly ApplicationDbContext _context;
+
+        public ProductsController(ApplicationDbContext context)
+        {
+            _context = context;
+        }
+
+        // GET: api/products
+        [HttpGet]
+        public async Task<IActionResult> GetProducts()
+        {
+            var products = await _context.Products.ToListAsync();
+            return Ok(products);
+        }
+
+        // GET: api/products/{id}
+        [HttpGet("{id}")]
+        public async Task<IActionResult> GetProduct(int id)
+        {
+            var product = await _context.Products.FindAsync(id);
+            if (product == null)
+            {
+                return NotFound();
+            }
+            return Ok(product);
+        }
+
+        // POST: api/products
+        [HttpPost]
+        public async Task<IActionResult> CreateProduct([FromBody] Product product)
+        {
+            if (!ModelState.IsValid)
+            {
+                return BadRequest(ModelState);
+            }
+            _context.Products.Add(product);
+            await _context.SaveChangesAsync();
+            return CreatedAtAction(nameof(GetProduct), new { id = product.Id }, product);
+        }
+
+        // PUT: api/products/{id}
+        [HttpPut("{id}")]
+        public async Task<IActionResult> UpdateProduct(int id, [FromBody] Product updatedProduct)
+        {
+            if (id != updatedProduct.Id)
+            {
+                return BadRequest();
+            }
+            if (!ModelState.IsValid)
+            {
+                return BadRequest(ModelState);
+            }
+            _context.Entry(updatedProduct).State = EntityState.Modified;
+            try
+            {
+                await _context.SaveChangesAsync();
+            }
+            catch (DbUpdateConcurrencyException)
+            {
+                if (!_context.Products.Any(p => p.Id == id))
+                {
+                    return NotFound();
+                }
+                else
+                {
+                    throw;
+                }
+            }
+            return NoContent();
+        }
+
+        // DELETE: api/products/{id}
+        [HttpDelete("{id}")]
+        public async Task<IActionResult> DeleteProduct(int id)
+        {
+            var product = await _context.Products.FindAsync(id);
+            if (product == null)
+            {
+                return NotFound();
+            }
+            _context.Products.Remove(product);
+            await _context.SaveChangesAsync();
+            return NoContent();
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -10,3 +10,22 @@ fontend Dashboard
 ![image](https://github.com/user-attachments/assets/8ddf0b2e-7e6f-411e-8298-6bc568ca5b32)
 
 
+
+## Product API Endpoints
+
+This API allows managing products and their prices.
+
+- `GET /api/products` - list all products
+- `GET /api/products/{id}` - get a product by id
+- `POST /api/products` - create a new product
+- `PUT /api/products/{id}` - update an existing product
+- `DELETE /api/products/{id}` - delete a product
+
+A sample request to create a product using `curl`:
+
+```bash
+curl -X POST https://localhost:5001/api/products \
+     -H "Content-Type: application/json" \
+     -d '{"name":"Sample","price":99.99}'
+```
+


### PR DESCRIPTION
## Summary
- create a `ProductsController` for CRUD operations
- document product API endpoints in README

## Testing
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_6841d896b438832ca10b916dafc0a788